### PR TITLE
Release v0.3.2: Refactor GitHub Actions workflow and update documentation

### DIFF
--- a/.github/workflows/near-rewards.yml
+++ b/.github/workflows/near-rewards.yml
@@ -7,16 +7,20 @@ on:
     branches: [ main ]     # Start on main branch updates
 
 jobs:
-  track-metrics:
+  calculate-rewards:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: '18'
 
-      - name: Run Metrics Collection
+      - name: Calculate Rewards
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPO: ${{ github.repository }}
-        run: npx near-protocol-rewards track
+        run: npx near-protocol-rewards calculate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2024-12-09
+
+### Changed
+
+- Renamed GitHub Actions workflow job from `track-metrics` to `calculate-rewards`
+- Updated workflow step name for clarity
+- Added required permissions block to workflow file
+- Standardized command terminology across documentation
+
+### Fixed
+
+- Fixed GitHub Actions workflow using deprecated `track` command
+- Added missing permissions in workflow file
+- Updated all documentation references to use `calculate` instead of `track`
+- Ensured consistent terminology across all documentation
+
+### Migration
+
+- Existing users should update their `.github/workflows/near-rewards.yml`:
+
+  ```yaml
+  jobs:
+    calculate-rewards:    # Changed from track-metrics
+      permissions:        # Added permissions block
+        contents: read
+        issues: read
+        pull-requests: read
+      steps:
+        # ... other steps ...
+        - name: Calculate Rewards    # Updated name
+          run: npx near-protocol-rewards calculate    # Changed from track
+  ```
+
+- No data loss: All historical metrics are preserved
+- No token changes needed: Uses same GitHub security
+
 ## [0.3.1] - 2024-12-08
 
 ### Added

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,7 +92,7 @@ try {
 ## Best Practices
 
 1. **Security**
-   - Use GitHub Actions for automated tracking
+   - Use GitHub Actions for automated rewards calculation
    - Leverage GitHub's built-in security
    - Never expose tokens in logs
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,9 +21,11 @@
 
 ### "track command not working"
 
-- The `track` command is ONLY for GitHub Actions
-- You should only run `init` on your local machine
-- GitHub Actions will run `track` automatically
+⚠️ The `track` command has been replaced with `calculate`:
+
+- Use `calculate` in GitHub Actions and locally
+- Run `init` to update your workflow file
+- Your metrics history is preserved
 
 ## GitHub Actions
 
@@ -72,17 +74,17 @@ npx near-protocol-rewards calculate
 
 ### "calculate command not working"
 
-1. Check environment variables:
+1. In GitHub Actions:
+   - Run `init` to generate the correct workflow
+   - Check Actions tab for any errors
+   - Verify workflow permissions
 
-```bash
-echo $GITHUB_TOKEN
-echo $GITHUB_REPO
-```
-
-2. Verify correct format:
-
-- GITHUB_REPO should be "owner/repo"
-- GITHUB_TOKEN needs 'repo' scope
+2. For local testing:
+   ```bash
+   export GITHUB_TOKEN="your_github_pat_token"
+   export GITHUB_REPO="owner/repo"
+   npx near-protocol-rewards calculate
+   ```
 
 ### "Rewards showing $0 or incorrect level?"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "near-protocol-rewards",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "near-protocol-rewards",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^19.0.0",
         "commander": "11.1.0",
         "dotenv": "^16.0.0",
+        "near-protocol-rewards": "0.3.1",
         "zod": "3.23.8"
       },
       "bin": {
@@ -4433,6 +4434,24 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/near-protocol-rewards": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/near-protocol-rewards/-/near-protocol-rewards-0.3.1.tgz",
+      "integrity": "sha512-ULLOwZgJMs2FkgTkp9lN5J5G5jlMgattPegetOdfUSEirWJZlZ9bxysIVORlIgoqpTdGTc2eTNekr924AmmwMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/rest": "^19.0.0",
+        "commander": "11.1.0",
+        "dotenv": "^16.0.0",
+        "zod": "3.23.8"
+      },
+      "bin": {
+        "near-protocol-rewards": "dist/src/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-protocol-rewards",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A transparent, metric-based rewards system for NEAR projects",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -37,6 +37,7 @@
     "@octokit/rest": "^19.0.0",
     "commander": "11.1.0",
     "dotenv": "^16.0.0",
+    "near-protocol-rewards": "0.3.1",
     "zod": "3.23.8"
   },
   "devDependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,19 +38,23 @@ on:
     branches: [ main ]     # Start on main branch updates
 
 jobs:
-  track-metrics:
+  calculate-rewards:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: '18'
 
-      - name: Run Metrics Collection
+      - name: Calculate Rewards
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPO: \${{ github.repository }}
-        run: npx near-protocol-rewards track
+        run: npx near-protocol-rewards calculate
 `;
 
       writeFileSync(join(workflowDir, 'near-rewards.yml'), workflowContent);


### PR DESCRIPTION
Release v0.3.2: Refactor GitHub Actions workflow and update documentation

- Renamed GitHub Actions job from `track-metrics` to `calculate-rewards` for clarity.
- Updated workflow step names and added required permissions block in the workflow file.
- Replaced deprecated `track` command with `calculate` in all relevant documentation and code.
- Ensured consistent terminology across documentation, emphasizing the new `calculate` command.
- Provided migration instructions for existing users to update their workflow files without data loss.

This release enhances clarity and functionality in the rewards calculation process.