### PR TITLE
[PR-14] Fix logger return undefined in CLI

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -32,7 +32,11 @@ export class ConsoleLogger implements ILogger {
 
   info(message: string, context?: Record<string, unknown>): void {
     if (this.shouldLog("info")) {
-      console.info(message, context);
+      if (context) {
+        console.info(message, context);
+      } else {
+        console.info(message);
+      }
     }
   }
 


### PR DESCRIPTION
Fix this issue about [Remove Confusing CLI Error Logging That Displays “Undefined” #14](https://github.com/jbarnes850/near-protocol-rewards/issues/14) 

- Modify `info logging` to not return any context with dont have

- Its not breaking change, just remove undefined return in info logs

![returnconsole](https://github.com/user-attachments/assets/f6cfc785-10d8-4938-a0c0-0fabef6116c0)
